### PR TITLE
Support for RN >= 0.60 and autolinking

### DIFF
--- a/KontaktBeacons.podspec
+++ b/KontaktBeacons.podspec
@@ -1,5 +1,5 @@
 require 'json'
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name          = "KontaktBeacons"

--- a/docs/setup.ios.md
+++ b/docs/setup.ios.md
@@ -20,11 +20,11 @@ When installing both, Android and iOS, steps _1_ and _2_ only have to be run onc
       	$ npm install --save react-native-kontaktio
       	```
 
-2.  Link module (use `rnpm` for React Native versions older than `0.27`)
+2. **(Skip for RN >= 0.60)** Link module (use `rnpm` for React Native versions older than `0.27`)
 
         react-native link react-native-kontaktio
 
-3.  Manually link **Kontakt.io SDK**
+3. **(Skip for RN >= 0.60)** Manually link **Kontakt.io SDK**
 
     - Open the projects workspace in **XCode**
 
@@ -47,7 +47,7 @@ When installing both, Android and iOS, steps _1_ and _2_ only have to be run onc
 
     It should now also appear both in the **`Embedded Binaries`** section as well as in the **`Linked Frameworks and Libraries`** section below it.
 
-4.  Add Framework Search paths so that Xcode can find the added framework
+4. **(Skip for RN >= 0.60)** Add Framework Search paths so that Xcode can find the added framework
 
     - Go to the **Build Settings** tab and search for **"framework search paths"**.
     - Add the following to _Framework Search Paths_ (select **recursive [v]**):
@@ -58,7 +58,7 @@ When installing both, Android and iOS, steps _1_ and _2_ only have to be run onc
 
       ![](images/ios_installation_step04.png)
 
-5.  Add run script
+5. **(Skip for RN >= 0.60)** Add run script
 
     - In the **`Build Phases`** tab, click the **`+`** button at the top and select **`New Run Script Phase`**. Enter the following code into the script text field:
 

--- a/docs/setup.ios.md
+++ b/docs/setup.ios.md
@@ -20,6 +20,14 @@ When installing both, Android and iOS, steps _1_ and _2_ only have to be run onc
       	$ npm install --save react-native-kontaktio
       	```
 
+    **(For RN >= 0.60)**
+    - `Update pods`
+
+        ```bash
+        $ cd ios
+        $ pod install
+        ```
+
 2. **(Skip for RN >= 0.60)** Link module (use `rnpm` for React Native versions older than `0.27`)
 
         react-native link react-native-kontaktio

--- a/ios/KontaktBeacons.m
+++ b/ios/KontaktBeacons.m
@@ -6,7 +6,7 @@
   #import <React/RCTConvert.h>
 #endif
 
-#import <KontaktSDK/KontaktSDK.h>
+#import <KontaktSDK.h>
 
 @interface KontaktBeacons() <KTKBeaconManagerDelegate,
     KTKDevicesManagerDelegate,KTKEddystoneManagerDelegate>


### PR DESCRIPTION
Basically this PR will fix the issue importing iOS code using `autolinking`. The feature was [introduced in 0.60](https://facebook.github.io/react-native/blog/2019/07/03/version-60). 

Should fixes a bunch of recent issues such as:

https://github.com/Driversnote-Dev/react-native-kontaktio/issues/65
https://github.com/Driversnote-Dev/react-native-kontaktio/issues/64
https://github.com/Driversnote-Dev/react-native-kontaktio/issues/59

This changes are also backwards compatible with everything lower than 0.60.

I think `setup.ios.md` could be updated in some other way, but I could not decide exactly how, feel free to update / suggest!

Please note that I have not checked how android side works yet. At the moment I cannot just do it, so if somebody can try this PR please also check the android side and let me know 🙂