### PR TITLE
Changing kontakt package source, updating version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,5 +92,5 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
-    compile "com.kontaktio:sdk:5.0.0"
+    compile 'io.kontakt.mvn:sdk:5.0.15'
 }


### PR DESCRIPTION
Gradle couldn't find "com.kontaktio:sdk:5.0.0". Changed to source listed in the Kontakt Android SDK [readme](https://github.com/kontaktio/kontakt-android-sdk#quickstart). This change fixed my android build issue (Driversnote-Dev/react-native-kontaktio#83)