### PR TITLE
Migrate to androidx

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kontakt.io SDK Versions of newest release:
 
 | OS          | SDK Version                                                                                              |
 | :---------- | :------------------------------------------------------------------------------------------------------- |
-| **Android** | [5.0.15](https://github.com/kontaktio/kontakt-android-sdk)                                               |
+| **Android** | [5.0.14](https://github.com/kontaktio/kontakt-android-sdk)                                               |
 | **iOS**     | [3.0.4](https://github.com/kontaktio/kontakt-ios-sdk/tree/v3.0.4)                                        |
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,8 +89,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"  // From node_modules
     compile 'io.kontakt.mvn:sdk:5.0.15'
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,8 +89,8 @@ android {
 }
 
 dependencies {
-    compile 'io.kontakt.mvn:sdk:5.0.15'
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "io.kontakt.mvn:sdk:5.0.14"
 }

--- a/android/src/main/java/com/artirigo/kontaktio/ReactUtils.java
+++ b/android/src/main/java/com/artirigo/kontaktio/ReactUtils.java
@@ -1,6 +1,6 @@
 package com.artirigo.kontaktio;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;


### PR DESCRIPTION
Migrate support libraries to androidx dependencies.

Downgrade Android Kontakt SDK to v. 5.0.14 which is the last version to target Android SDK 30 (Android 11) - from 5.0.15 the Android Kontakt SDK targets Android SDK 31 (Android 12) which triggers a new bluetooth security model even if the host app targets, for example, Android SDK 30.